### PR TITLE
chore: set index.html as plugin entry for Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# [1.0.0](https://github.com/inchanS/logseq-block-extractor/compare/v0.5.1...v1.0.0) (2025-06-06)
+
+
+### Bug Fixes
+
+* .gitignore ([cd29476](https://github.com/inchanS/logseq-block-extractor/commit/cd294766d2a5c0db6d79f5b41cef59a473ed3f36))
+
+
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>logseq-plugin-block-extractor</title>
+</head>
+<body>
+<div class="root"></div>
+<script type="module" src="./src/index.ts"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "logseq-block-extractor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": " Filter the reference block for a specific page in Logseq and download it as a markdown file.",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.html",
   "logseq": {
     "id": "logseq-block-extractor",
     "title": "Block Extractor",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,7 @@ export default defineConfig({
     build: {
         target: 'esnext',
         minify: false, // Disable minification for debugging
-        outDir: 'dist',
-        rollupOptions: {
-            input: 'src/index.ts',
-            output: {
-                entryFileNames: 'index.js',
-                format: 'es'
-            }
-        }
+        outDir: 'dist'
     },
     base: './'
 })


### PR DESCRIPTION
Solve for https://github.com/logseq/marketplace/pull/657

Hi @inchanS Sorry for the current Desktop version (0.10.12), there is a bug when using `dist/index.js` as the entry for the plugin in the Marketplace, so a temporary solution is to use `dist/index.html`. This issue has been fixed in the latest master branch.

related threads: https://github.com/logseq/marketplace/pull/635